### PR TITLE
#31: Avoid unnecessary `setAutoCommit()` calls in `Transaction`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.0] - unreleased
 
 - [PR #33](https://github.com/itsallcode/simple-jdbc/pull/33): Update dependencies
+- [#32](https://github.com/itsallcode/simple-jdbc/issues/32): Add support for data sources
+- [#31](https://github.com/itsallcode/simple-jdbc/issues/31): Avoid unnecessary `setAutoCommit()` calls in `Transaction`
 
 ## [0.8.0] - 2024-11-03
 

--- a/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
+++ b/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
@@ -101,6 +101,14 @@ public class SimpleConnection implements DbOperations {
         }
     }
 
+    boolean getAutoCommit() {
+        try {
+            return this.connection.getAutoCommit();
+        } catch (final SQLException e) {
+            throw new UncheckedSQLException("Failed to get autoCommit", e);
+        }
+    }
+
     void rollback() {
         try {
             this.connection.rollback();

--- a/src/main/java/org/itsallcode/jdbc/Transaction.java
+++ b/src/main/java/org/itsallcode/jdbc/Transaction.java
@@ -11,8 +11,11 @@ import org.itsallcode.jdbc.resultset.generic.Row;
 public final class Transaction implements DbOperations {
 
     private final SimpleConnection connection;
+    private boolean closed;
+    private boolean committed;
+    private boolean rolledBack;
 
-    private Transaction(final SimpleConnection connection) {
+    Transaction(final SimpleConnection connection) {
         this.connection = connection;
     }
 
@@ -23,62 +26,97 @@ public final class Transaction implements DbOperations {
 
     /**
      * Commit the transaction.
+     * <p>
+     * No further operations are allowed on this transaction afterwards.
      */
     public void commit() {
+        checkOperationAllowed();
         connection.commit();
+        this.committed = true;
     }
 
     /**
      * Rollback the transaction.
+     * <p>
+     * No further operations are allowed on this transaction afterwards.
      */
     public void rollback() {
+        checkOperationAllowed();
         connection.rollback();
+        this.rolledBack = true;
     }
 
     @Override
     public void executeStatement(final String sql) {
+        checkOperationAllowed();
         connection.executeStatement(sql);
     }
 
     @Override
     public void executeStatement(final String sql, final PreparedStatementSetter preparedStatementSetter) {
+        checkOperationAllowed();
         connection.executeStatement(sql, preparedStatementSetter);
     }
 
     @Override
     public SimpleResultSet<Row> query(final String sql) {
+        checkOperationAllowed();
         return connection.query(sql);
     }
 
     @Override
     public void executeScript(final String sqlScript) {
+        checkOperationAllowed();
         connection.executeScript(sqlScript);
     }
 
     @Override
     public <T> SimpleResultSet<T> query(final String sql, final RowMapper<T> rowMapper) {
+        checkOperationAllowed();
         return connection.query(sql, rowMapper);
     }
 
     @Override
     public <T> SimpleResultSet<T> query(final String sql, final PreparedStatementSetter preparedStatementSetter,
             final RowMapper<T> rowMapper) {
+        checkOperationAllowed();
         return connection.query(sql, preparedStatementSetter, rowMapper);
     }
 
     @Override
     public <T> BatchInsertBuilder<T> batchInsert(final Class<T> rowType) {
+        checkOperationAllowed();
         return connection.batchInsert(rowType);
+    }
+
+    private void checkOperationAllowed() {
+        if (this.closed) {
+            throw new IllegalStateException("Operation not allowed on closed transaction");
+        }
+        if (this.rolledBack) {
+            throw new IllegalStateException("Operation not allowed on rolled back transaction");
+        }
+        if (this.committed) {
+            throw new IllegalStateException("Operation not allowed on committed transaction");
+        }
     }
 
     /**
      * Rollback transaction and enable auto commit.
      * <p>
      * Explicitly run {@link #commit()} before to commit your transaction.
+     * <p>
+     * No further operations are allowed on this transaction afterwards.
      */
     @Override
     public void close() {
-        this.rollback();
+        if (closed) {
+            return;
+        }
+        if (!rolledBack && !committed) {
+            this.rollback();
+        }
         connection.setAutoCommit(true);
+        this.closed = true;
     }
 }

--- a/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
@@ -1,5 +1,6 @@
 package org.itsallcode.jdbc;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 
@@ -44,6 +45,12 @@ class SimpleConnectionTest {
     void setAutoCommit() throws SQLException {
         testee().setAutoCommit(false);
         verify(connectionMock).setAutoCommit(false);
+    }
+
+    @Test
+    void getAutoCommit() throws SQLException {
+        when(connectionMock.getAutoCommit()).thenReturn(true);
+        assertThat(testee().getAutoCommit()).isTrue();
     }
 
     @Test

--- a/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
@@ -48,17 +48,25 @@ class SimpleConnectionTest {
     }
 
     @Test
+    void setAutoCommitFails() throws SQLException {
+        doThrow(new SQLException("expected")).when(connectionMock).setAutoCommit(false);
+        final SimpleConnection testee = testee();
+        assertThatThrownBy(() -> testee.setAutoCommit(false)).isInstanceOf(UncheckedSQLException.class)
+                .hasMessage("Failed to set autoCommit to false: expected");
+    }
+
+    @Test
     void getAutoCommit() throws SQLException {
         when(connectionMock.getAutoCommit()).thenReturn(true);
         assertThat(testee().getAutoCommit()).isTrue();
     }
 
     @Test
-    void setAutoCommitFails() throws SQLException {
-        doThrow(new SQLException("expected")).when(connectionMock).setAutoCommit(false);
+    void getAutoCommitFails() throws SQLException {
+        doThrow(new SQLException("expected")).when(connectionMock).getAutoCommit();
         final SimpleConnection testee = testee();
-        assertThatThrownBy(() -> testee.setAutoCommit(false)).isInstanceOf(UncheckedSQLException.class)
-                .hasMessage("Failed to set autoCommit to false: expected");
+        assertThatThrownBy(() -> testee.getAutoCommit()).isInstanceOf(UncheckedSQLException.class)
+                .hasMessage("Failed to get autoCommit: expected");
     }
 
     @Test

--- a/src/test/java/org/itsallcode/jdbc/TransactionTest.java
+++ b/src/test/java/org/itsallcode/jdbc/TransactionTest.java
@@ -1,0 +1,130 @@
+package org.itsallcode.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TransactionTest {
+    @Mock
+    SimpleConnection connectionMock;
+
+    static Stream<Arguments> operations() {
+        return Stream.of(
+                operation(tx -> tx.executeScript("script")),
+                operation(tx -> tx.executeStatement("sql")),
+                operation(tx -> tx.executeStatement("sql", null)),
+                operation(tx -> tx.query("sql")),
+                operation(tx -> tx.query("sql", null)),
+                operation(tx -> tx.query("sql", null, null)),
+                operation(tx -> tx.batchInsert(null)),
+                operation(tx -> tx.commit()),
+                operation(tx -> tx.rollback()));
+    }
+
+    static Arguments operation(final Consumer<Transaction> operation) {
+        return Arguments.of(operation);
+    }
+
+    @ParameterizedTest
+    @MethodSource("operations")
+    void operationFailsAfterClose(final Consumer<Transaction> operation) {
+        final Transaction testee = testee();
+        testee.close();
+        assertThatThrownBy(() -> operation.accept(testee))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Operation not allowed on closed transaction");
+    }
+
+    @ParameterizedTest
+    @MethodSource("operations")
+    void operationFailsAfterCommit(final Consumer<Transaction> operation) {
+        final Transaction testee = testee();
+        testee.commit();
+        assertThatThrownBy(() -> operation.accept(testee))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Operation not allowed on committed transaction");
+    }
+
+    @ParameterizedTest
+    @MethodSource("operations")
+    void operationFailsAfterRollback(final Consumer<Transaction> operation) {
+        final Transaction testee = testee();
+        testee.rollback();
+        assertThatThrownBy(() -> operation.accept(testee))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("Operation not allowed on rolled back transaction");
+    }
+
+    @Test
+    void commit() {
+        testee().commit();
+        verify(connectionMock).commit();
+    }
+
+    @Test
+    void rollback() {
+        testee().rollback();
+        verify(connectionMock).rollback();
+    }
+
+    @Test
+    void closingRollsBack() {
+        final Transaction testee = testee();
+        testee.close();
+        verify(connectionMock).rollback();
+    }
+
+    @Test
+    void closingDoesNotCloseConnection() {
+        final Transaction testee = testee();
+        testee.close();
+        verify(connectionMock, never()).close();
+    }
+
+    @Test
+    void closingAlreadyClosedTransactionSucceeds() {
+        final Transaction testee = testee();
+        testee.close();
+        assertDoesNotThrow(testee::close);
+    }
+
+    @Test
+    void closingAlreadyClosedTransactionRollsBackOnlyOnce() {
+        final Transaction testee = testee();
+        testee.close();
+        testee.close();
+        verify(connectionMock, times(1)).rollback();
+    }
+
+    @Test
+    void closingRolledBackTransactionDoesNotRollback() {
+        final Transaction testee = testee();
+        testee.rollback();
+        testee.close();
+        verify(connectionMock, times(1)).rollback();
+    }
+
+    @Test
+    void closingCommittedTransactionDoesNotRollback() {
+        final Transaction testee = testee();
+        testee.commit();
+        testee.close();
+        verify(connectionMock, never()).rollback();
+    }
+
+    private Transaction testee() {
+        return new Transaction(connectionMock);
+    }
+}


### PR DESCRIPTION
Closes