### PR TITLE
Wrap connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.10.0] - unreleased
 
+- [PR #38](https://github.com/itsallcode/simple-jdbc/pull/38): Add method `wrap()` to `SimpleConnection`
+
 ## [0.9.0] - 2024-12-23
 
 - [PR #33](https://github.com/itsallcode/simple-jdbc/pull/33): Update dependencies

--- a/README.md
+++ b/README.md
@@ -164,6 +164,13 @@ To calculate and view test coverage:
 open build/reports/jacoco/test/html/index.html
 ```
 
+### View Generated Javadoc
+
+```sh
+./gradlew javadoc
+open build/docs/javadoc/index.html
+```
+
 ### Publish to Maven Central
 
 #### Preparations

--- a/build.gradle
+++ b/build.gradle
@@ -24,8 +24,8 @@ java {
 
 javadoc {
     failOnError = true
-    options.addBooleanOption('html5', true)
     options.addStringOption('Xwerror', '-quiet')
+    options.addBooleanOption('linksource', true)
 }
 
 tasks.withType(JavaCompile) {

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -4,10 +4,12 @@
  * <ul>
  * <li>Create a {@link org.itsallcode.jdbc.SimpleConnection}
  * <ul>
- * <li>with a connection factory using {@link java.sql.DriverManager}, see
+ * <li>... with a connection factory using {@link java.sql.DriverManager}, see
  * {@link org.itsallcode.jdbc.DataSourceConnectionFactory}</li>
- * <li>with a {@link javax.sql.DataSource}, see
+ * <li>... with a {@link javax.sql.DataSource}, see
  * {@link org.itsallcode.jdbc.DataSourceConnectionFactory}</li>
+ * <li>... with an existing {@link java.sql.Connection}, see
+ * {@link org.itsallcode.jdbc.SimpleConnection#wrap(Connection, DbDialect)}</li>
  * </ul>
  * </li>
  * <li>Execute statements

--- a/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
+++ b/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
@@ -18,6 +18,7 @@ import org.itsallcode.jdbc.statement.ParamSetterProvider;
  * <ul>
  * <li>{@link ConnectionFactory#create(String, String, String)}</li>
  * <li>or {@link DataSourceConnectionFactory#getConnection()}</li>
+ * <li>or {@link #wrap(Connection, DbDialect)}</li>
  * </ul>
  */
 public class SimpleConnection implements DbOperations {
@@ -33,6 +34,19 @@ public class SimpleConnection implements DbOperations {
         this.context = Objects.requireNonNull(context, "context");
         this.dialect = Objects.requireNonNull(dialect, "dialect");
         this.paramSetterProvider = new ParamSetterProvider(dialect);
+    }
+
+    /**
+     * Wrap an existing {@link Connection} with a {@link SimpleConnection}.
+     * <p>
+     * Note: Calling {@link #close()} will close the underlying connection.
+     * 
+     * @param connection existing connection
+     * @param dialect    database dialect
+     * @return wrapped connection
+     */
+    public static SimpleConnection wrap(final Connection connection, final DbDialect dialect) {
+        return new SimpleConnection(connection, Context.builder().build(), dialect);
     }
 
     /**

--- a/src/main/java/org/itsallcode/jdbc/Transaction.java
+++ b/src/main/java/org/itsallcode/jdbc/Transaction.java
@@ -129,6 +129,8 @@ public final class Transaction implements DbOperations {
      * Explicitly run {@link #commit()} before to commit your transaction.
      * <p>
      * No further operations are allowed on this transaction afterwards.
+     * <p>
+     * This <em>does not</em> close the connection, so you can continue using it.
      */
     @Override
     public void close() {

--- a/src/test/java/org/itsallcode/jdbc/SimpleConnectionITest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimpleConnectionITest.java
@@ -5,11 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
-import java.sql.JDBCType;
-import java.sql.SQLException;
+import java.sql.*;
 import java.util.*;
 import java.util.stream.Stream;
 
+import org.itsallcode.jdbc.dialect.H2Dialect;
 import org.itsallcode.jdbc.resultset.RowMapper;
 import org.itsallcode.jdbc.resultset.SimpleResultSet;
 import org.itsallcode.jdbc.resultset.generic.Row;
@@ -19,6 +19,16 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 class SimpleConnectionITest {
+
+    @Test
+    void wrap() throws SQLException {
+        try (Connection existingConnection = DriverManager.getConnection(H2TestFixture.H2_MEM_JDBC_URL);
+                SimpleConnection connection = SimpleConnection.wrap(existingConnection, new H2Dialect())) {
+            connection.executeStatement("CREATE TABLE TEST(ID INT, NAME VARCHAR(255))");
+            assertDoesNotThrow(() -> connection.executeStatement("select count(*) from test"));
+        }
+    }
+
     @Test
     void executeStatement() {
         try (SimpleConnection connection = H2TestFixture.createMemConnection()) {

--- a/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimpleConnectionTest.java
@@ -42,6 +42,13 @@ class SimpleConnectionTest {
     }
 
     @Test
+    void closeClosesWrappedConnection() throws SQLException {
+        final SimpleConnection testee = SimpleConnection.wrap(connectionMock, new H2Dialect());
+        testee.close();
+        verify(connectionMock).close();
+    }
+
+    @Test
     void setAutoCommit() throws SQLException {
         testee().setAutoCommit(false);
         verify(connectionMock).setAutoCommit(false);


### PR DESCRIPTION
Add method `wrap()` to `SimpleConnection` to allow creating a new instance when only a normal `Connection` is available.