### PR TITLE
Add convenience methods for executing statements and queries with parameters in DbOperations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.10.0] - unreleased
 
 - [PR #38](https://github.com/itsallcode/simple-jdbc/pull/38): Add method `wrap()` to `SimpleConnection`
+- [PR #39](https://github.com/itsallcode/simple-jdbc/pull/39): Add convenience methods `executeStatement` and `query` with generic parameters to `DbOperations`
 
 ## [0.9.0] - 2024-12-23
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
             library('assertj', 'org.assertj:assertj-core:3.27.0')
             library('h2', 'com.h2database:h2:2.3.232')
             library('junitPioneer', 'org.junit-pioneer:junit-pioneer:2.2.0')
-            library('equalsverifier', 'nl.jqno.equalsverifier:equalsverifier:3.17.5')
+            library('equalsverifier', 'nl.jqno.equalsverifier:equalsverifier:3.18')
             library('tostringverifier', 'com.jparams:to-string-verifier:1.4.8')
             library('hamcrest', 'org.hamcrest:hamcrest:3.0')
             library('hamcrestResultSetMatcher', 'com.exasol:hamcrest-resultset-matcher:1.6.3')

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -65,7 +65,6 @@
  * {@link org.itsallcode.jdbc.UncheckedSQLException}</li>
  * </ul>
  */
-
 module org.itsallcode.jdbc {
     exports org.itsallcode.jdbc;
     exports org.itsallcode.jdbc.batch;

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -16,8 +16,11 @@
  * <ul>
  * <li>... single statement:
  * {@link org.itsallcode.jdbc.DbOperations#executeStatement(String)}</li>
- * <li>... with a prepared statement:
+ * <li>... with a prepared statement and generic parameters:
+ * {@link org.itsallcode.jdbc.DbOperations#executeStatement(String, List)}</li>
+ * <li>... with a prepared statement and custom parameter setter:
  * {@link org.itsallcode.jdbc.DbOperations#executeStatement(String, org.itsallcode.jdbc.PreparedStatementSetter)}</li>
+ * 
  * <li>... semicolon separated SQL script:
  * {@link org.itsallcode.jdbc.DbOperations#executeScript(String)}</li>
  * </ul>
@@ -28,7 +31,9 @@
  * <li>...with a {@link org.itsallcode.jdbc.resultset.RowMapper}, returning
  * custom result types:
  * {@link org.itsallcode.jdbc.DbOperations#query(String, org.itsallcode.jdbc.resultset.RowMapper)}</li>
- * <li>...with a prepared statement:
+ * <li>...with a prepared statement and generic parameters:
+ * {@link org.itsallcode.jdbc.DbOperations#query(String, List, org.itsallcode.jdbc.resultset.RowMapper)}</li>
+ * <li>...with a prepared statement and custom parameter setter:
  * {@link org.itsallcode.jdbc.DbOperations#query(String, org.itsallcode.jdbc.PreparedStatementSetter, org.itsallcode.jdbc.resultset.RowMapper)}</li>
  * </ul>
  * </li>
@@ -60,6 +65,7 @@
  * {@link org.itsallcode.jdbc.UncheckedSQLException}</li>
  * </ul>
  */
+
 module org.itsallcode.jdbc {
     exports org.itsallcode.jdbc;
     exports org.itsallcode.jdbc.batch;

--- a/src/main/java/org/itsallcode/jdbc/DbOperations.java
+++ b/src/main/java/org/itsallcode/jdbc/DbOperations.java
@@ -35,7 +35,10 @@ public interface DbOperations extends AutoCloseable {
      * 
      * @param sql SQL statement
      */
-    void executeStatement(final String sql);
+    default void executeStatement(final String sql) {
+        this.executeStatement(sql, stmt -> {
+        });
+    }
 
     /**
      * Execute a single SQL statement as a prepared statement with placeholders.
@@ -77,7 +80,10 @@ public interface DbOperations extends AutoCloseable {
      * @param rowMapper row mapper
      * @return the result set
      */
-    <T> SimpleResultSet<T> query(final String sql, final RowMapper<T> rowMapper);
+    default <T> SimpleResultSet<T> query(final String sql, final RowMapper<T> rowMapper) {
+        return query(sql, ps -> {
+        }, rowMapper);
+    }
 
     /**
      * Execute a SQL query, set parameters and return a {@link SimpleResultSet

--- a/src/main/java/org/itsallcode/jdbc/GenericParameterSetter.java
+++ b/src/main/java/org/itsallcode/jdbc/GenericParameterSetter.java
@@ -1,0 +1,27 @@
+package org.itsallcode.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This {@link PreparedStatement} uses
+ * {@link PreparedStatement#setObject(int, Object)} to set parameters from a
+ * {@link List}.
+ */
+class GenericParameterSetter implements PreparedStatementSetter {
+
+    private final List<Object> values;
+
+    GenericParameterSetter(final List<Object> values) {
+        this.values = new ArrayList<>(values);
+    }
+
+    @Override
+    public void setValues(final PreparedStatement preparedStatement) throws SQLException {
+        for (int i = 0; i < values.size(); i++) {
+            preparedStatement.setObject(i + 1, values.get(i));
+        }
+    }
+}

--- a/src/main/java/org/itsallcode/jdbc/GenericParameterSetter.java
+++ b/src/main/java/org/itsallcode/jdbc/GenericParameterSetter.java
@@ -2,8 +2,7 @@ package org.itsallcode.jdbc;
 
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 /**
  * This {@link PreparedStatement} uses
@@ -12,16 +11,17 @@ import java.util.List;
  */
 class GenericParameterSetter implements PreparedStatementSetter {
 
-    private final List<Object> values;
+    private final List<Object> parameters;
 
-    GenericParameterSetter(final List<Object> values) {
-        this.values = new ArrayList<>(values);
+    GenericParameterSetter(final List<Object> parameters) {
+        Objects.requireNonNull(parameters, "parameters");
+        this.parameters = new ArrayList<>(parameters);
     }
 
     @Override
     public void setValues(final PreparedStatement preparedStatement) throws SQLException {
-        for (int i = 0; i < values.size(); i++) {
-            preparedStatement.setObject(i + 1, values.get(i));
+        for (int i = 0; i < parameters.size(); i++) {
+            preparedStatement.setObject(i + 1, parameters.get(i));
         }
     }
 }

--- a/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
+++ b/src/main/java/org/itsallcode/jdbc/SimpleConnection.java
@@ -59,12 +59,6 @@ public class SimpleConnection implements DbOperations {
     }
 
     @Override
-    public void executeStatement(final String sql) {
-        this.executeStatement(sql, stmt -> {
-        });
-    }
-
-    @Override
     public void executeStatement(final String sql, final PreparedStatementSetter preparedStatementSetter) {
         try (SimplePreparedStatement statement = prepareStatement(sql)) {
             statement.setValues(preparedStatementSetter);
@@ -75,12 +69,6 @@ public class SimpleConnection implements DbOperations {
     @Override
     public SimpleResultSet<Row> query(final String sql) {
         return query(sql, ContextRowMapper.generic(dialect));
-    }
-
-    @Override
-    public <T> SimpleResultSet<T> query(final String sql, final RowMapper<T> rowMapper) {
-        return query(sql, ps -> {
-        }, rowMapper);
     }
 
     @Override

--- a/src/main/java/org/itsallcode/jdbc/Transaction.java
+++ b/src/main/java/org/itsallcode/jdbc/Transaction.java
@@ -62,12 +62,6 @@ public final class Transaction implements DbOperations {
     }
 
     @Override
-    public void executeStatement(final String sql) {
-        checkOperationAllowed();
-        connection.executeStatement(sql);
-    }
-
-    @Override
     public void executeStatement(final String sql, final PreparedStatementSetter preparedStatementSetter) {
         checkOperationAllowed();
         connection.executeStatement(sql, preparedStatementSetter);
@@ -83,12 +77,6 @@ public final class Transaction implements DbOperations {
     public void executeScript(final String sqlScript) {
         checkOperationAllowed();
         connection.executeScript(sqlScript);
-    }
-
-    @Override
-    public <T> SimpleResultSet<T> query(final String sql, final RowMapper<T> rowMapper) {
-        checkOperationAllowed();
-        return connection.query(sql, rowMapper);
     }
 
     @Override

--- a/src/main/java/org/itsallcode/jdbc/resultset/ContextRowMapper.java
+++ b/src/main/java/org/itsallcode/jdbc/resultset/ContextRowMapper.java
@@ -29,7 +29,7 @@ public interface ContextRowMapper<T> {
     T mapRow(Context context, ResultSet resultSet, int rowNum) throws SQLException;
 
     /**
-     * Create a {@link ContextRowMapper} that creates generic {@link Row} objects.
+     * Create a {@link RowMapper} that creates generic {@link Row} objects.
      * 
      * @param dialect DB dialect
      * @return a new row mapper
@@ -39,7 +39,7 @@ public interface ContextRowMapper<T> {
     }
 
     /**
-     * Create a {@link ContextRowMapper} that creates {@link List}s of simple column
+     * Create a {@link RowMapper} that creates {@link List}s of simple column
      * objects.
      * 
      * @param dialect DB dialect

--- a/src/test/java/org/itsallcode/jdbc/GenericParameterSetterTest.java
+++ b/src/test/java/org/itsallcode/jdbc/GenericParameterSetterTest.java
@@ -1,0 +1,53 @@
+package org.itsallcode.jdbc;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GenericParameterSetterTest {
+    @Mock
+    PreparedStatement preparedStatementMock;
+
+    @Test
+    void nullParameter() {
+        assertThatThrownBy(() -> new GenericParameterSetter(null))
+                .isInstanceOf(NullPointerException.class)
+                .hasMessage("parameters");
+    }
+
+    @Test
+    void emptyParameterList() throws SQLException {
+        setParameters(List.of());
+        verifyNoInteractions(preparedStatementMock);
+    }
+
+    @Test
+    void singleParameter() throws SQLException {
+        setParameters(List.of(1));
+        verify(preparedStatementMock).setObject(1, 1);
+    }
+
+    @Test
+    void multipleParameters() throws SQLException {
+        setParameters(List.of(1, "b", 3.14));
+        final InOrder inOrder = inOrder(preparedStatementMock);
+        inOrder.verify(preparedStatementMock).setObject(1, 1);
+        inOrder.verify(preparedStatementMock).setObject(2, "b");
+        inOrder.verify(preparedStatementMock).setObject(3, 3.14);
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    void setParameters(final List<Object> parameters) throws SQLException {
+        new GenericParameterSetter(parameters).setValues(preparedStatementMock);
+    }
+}

--- a/src/test/java/org/itsallcode/jdbc/SimpleConnectionITest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimpleConnectionITest.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import org.itsallcode.jdbc.dialect.H2Dialect;
 import org.itsallcode.jdbc.resultset.RowMapper;
 import org.itsallcode.jdbc.resultset.SimpleResultSet;
+import org.itsallcode.jdbc.resultset.generic.ColumnValue;
 import org.itsallcode.jdbc.resultset.generic.Row;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -136,7 +137,7 @@ class SimpleConnectionITest {
                 final Iterator<Row> iterator = resultSet.iterator();
                 assertAll(
                         () -> assertThat(iterator.hasNext()).isFalse(),
-                        () -> assertThatThrownBy(() -> iterator.next()).isInstanceOf(NoSuchElementException.class));
+                        () -> assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class));
             }
         }
     }
@@ -176,7 +177,7 @@ class SimpleConnectionITest {
                         () -> assertThat(firstRow.columnValues().get(1).type().scale()).isZero(),
 
                         () -> assertThat(iterator.hasNext()).isFalse(),
-                        () -> assertThatThrownBy(() -> iterator.next()).isInstanceOf(NoSuchElementException.class));
+                        () -> assertThatThrownBy(iterator::next).isInstanceOf(NoSuchElementException.class));
             }
         }
     }
@@ -200,7 +201,7 @@ class SimpleConnectionITest {
                 final Iterator<Row> iterator = resultSet.iterator();
                 assertAll(
                         () -> assertThat(iterator).isNotNull(),
-                        () -> assertThatThrownBy(() -> resultSet.iterator()).isInstanceOf(IllegalStateException.class)
+                        () -> assertThatThrownBy(resultSet::iterator).isInstanceOf(IllegalStateException.class)
                                 .hasMessage("Only one iterator allowed per ResultSet"));
             }
         }
@@ -247,7 +248,7 @@ class SimpleConnectionITest {
                     .start();
 
             final List<List<Object>> result = connection.query("select * from test").stream()
-                    .map(row -> row.columnValues().stream().map(value -> value.value()).toList()).toList();
+                    .map(row -> row.columnValues().stream().map(ColumnValue::value).toList()).toList();
             assertAll(
                     () -> assertThat(result).hasSize(3),
                     () -> assertThat(result).isEqualTo(List.of(List.of(1, "a"), List.of(2, "b"), List.of(3, "c"))));


### PR DESCRIPTION
Introduce `executeStatement` and `query` methods in `DbOperations` that accept generic parameters for improved flexibility in executing SQL statements and queries.