### PR TITLE
Allow direct access to PreparedStatement for batch insert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [PR #38](https://github.com/itsallcode/simple-jdbc/pull/38): Add method `wrap()` to `SimpleConnection`
 - [PR #39](https://github.com/itsallcode/simple-jdbc/pull/39): Add convenience methods `executeStatement` and `query` with generic parameters to `DbOperations`
 - [PR #40](https://github.com/itsallcode/simple-jdbc/pull/40): Verify that operation on `SimpleConnection` are allowed
+- [PR #41](https://github.com/itsallcode/simple-jdbc/pull/41): Allow direct access to PreparedStatement for batch insert
 
 ## [0.9.0] - 2024-12-23
 

--- a/src/integrationTest/java/org/itsallcode/jdbc/BatchInsertPerformanceTest.java
+++ b/src/integrationTest/java/org/itsallcode/jdbc/BatchInsertPerformanceTest.java
@@ -2,12 +2,13 @@ package org.itsallcode.jdbc;
 
 import java.lang.reflect.*;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
-import org.itsallcode.jdbc.batch.RowBatchInsertBuilder;
+import org.itsallcode.jdbc.batch.*;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class BatchInsertPerformanceTest {
+    private static final int ROW_COUNT = 10_000_000;
+    private static final int MAX_BATCH_SIZE = BatchInsertBuilder.DEFAULT_MAX_BATCH_SIZE;
     @Mock
     SimpleConnection connectionMock;
     @Mock
@@ -23,18 +26,24 @@ class BatchInsertPerformanceTest {
 
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void performanceTestRowStmtSetter() {
-        final int rowCount = 10_000_000;
-        testee().into("TEST", List.of("ID", "NAME"))
+    void rowStatementSetter() {
+        rowTestee().into("TEST", List.of("ID", "NAME"))
                 .mapping((row, stmt) -> {
                     stmt.setInt(1, row.id);
                     stmt.setString(2, row.name);
-                }).rows(generateStream(rowCount)).start();
+                }).rows(generateStream(ROW_COUNT)).start();
     }
 
-    private RowBatchInsertBuilder<NameRow> testee() {
+    private RowBatchInsertBuilder<NameRow> rowTestee() {
         final PreparedStatement stmt = createNoopPreparedStatement();
-        return new RowBatchInsertBuilder<NameRow>(sql -> new SimplePreparedStatement(null, null, stmt, "sql"));
+        return new RowBatchInsertBuilder<NameRow>(sql -> new SimplePreparedStatement(null, null, stmt, "sql"))
+                .maxBatchSize(MAX_BATCH_SIZE);
+    }
+
+    private BatchInsertBuilder testee() {
+        final PreparedStatement stmt = createNoopPreparedStatement();
+        return new BatchInsertBuilder(sql -> new SimplePreparedStatement(null, null, stmt, "sql"))
+                .maxBatchSize(MAX_BATCH_SIZE);
     }
 
     private PreparedStatement createNoopPreparedStatement() {
@@ -54,10 +63,38 @@ class BatchInsertPerformanceTest {
 
     @Test
     @Timeout(value = 10, unit = TimeUnit.SECONDS)
-    void performanceTestObjectArray() {
-        final int rowCount = 10_000_000;
-        testee().into("TEST", List.of("ID", "NAME"))
-                .mapping(row -> new Object[] { row.id, row.name }).rows(generateStream(rowCount)).start();
+    void objectArray() {
+        rowTestee().into("TEST", List.of("ID", "NAME"))
+                .mapping(row -> new Object[] { row.id, row.name })
+                .rows(generateStream(ROW_COUNT))
+                .start();
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void directAdd() {
+        try (BatchInsert batch = testee().into("TEST", List.of("ID", "NAME")).build()) {
+            for (int i = 0; i < ROW_COUNT; i++) {
+                final int row = i;
+                batch.add(ps -> {
+                    ps.setInt(1, row);
+                    ps.setString(2, "name" + row);
+                });
+            }
+        }
+    }
+
+    @Test
+    @Timeout(value = 10, unit = TimeUnit.SECONDS)
+    void directAddBatch() throws SQLException {
+        try (BatchInsert batch = testee().into("TEST", List.of("ID", "NAME")).build()) {
+            final PreparedStatement statement = batch.getStatement();
+            for (int i = 0; i < ROW_COUNT; i++) {
+                statement.setInt(1, i);
+                statement.setString(2, "Name " + i);
+                batch.addBatch();
+            }
+        }
     }
 
     private Stream<NameRow> generateStream(final int rowCount) {

--- a/src/main/java/org/itsallcode/jdbc/SimpleParameterMetaData.java
+++ b/src/main/java/org/itsallcode/jdbc/SimpleParameterMetaData.java
@@ -67,7 +67,7 @@ public record SimpleParameterMetaData(List<Parameter> parameters) {
         /** Parameter will allow {@code NULL} values. */
         NULLABLE(ParameterMetaData.parameterNullable),
         /** Parameter nullability status is unknown. */
-        UNKNWON(ParameterMetaData.parameterNullableUnknown);
+        UNKNOWN(ParameterMetaData.parameterNullableUnknown);
 
         private final int mode;
 

--- a/src/main/java/org/itsallcode/jdbc/SimplePreparedStatement.java
+++ b/src/main/java/org/itsallcode/jdbc/SimplePreparedStatement.java
@@ -100,4 +100,13 @@ public class SimplePreparedStatement implements AutoCloseable {
             throw new UncheckedSQLException("Error getting parameter metadata", e);
         }
     }
+
+    /**
+     * Get the underlying {@link PreparedStatement}.
+     * 
+     * @return the underlying {@link PreparedStatement}
+     */
+    public PreparedStatement getStatement() {
+        return statement;
+    }
 }

--- a/src/main/java/org/itsallcode/jdbc/batch/BatchInsert.java
+++ b/src/main/java/org/itsallcode/jdbc/batch/BatchInsert.java
@@ -30,6 +30,9 @@ public class BatchInsert implements AutoCloseable {
 
     /**
      * Add a new row to the batch.
+     * <p>
+     * <em>Important:</em> This method automatically calls
+     * {@link PreparedStatement#addBatch()}. No need to call it separately.
      * 
      * @param preparedStatementSetter prepared statement setter that is used for
      *                                setting row values of the
@@ -37,6 +40,31 @@ public class BatchInsert implements AutoCloseable {
      */
     public void add(final PreparedStatementSetter preparedStatementSetter) {
         statement.setValues(preparedStatementSetter);
+        addBatch();
+    }
+
+    /**
+     * Get the {@link PreparedStatement} that is used for the batch insert. Use this
+     * to set values on the {@link PreparedStatement} before calling
+     * {@link #addBatch()}.
+     * <p>
+     * Use this method if you want to set values on the {@link PreparedStatement}
+     * directly and you need more control. Prefer using
+     * {@link #add(PreparedStatementSetter)} if possible.
+     * 
+     * @return the {@link PreparedStatement} used for the batch insert
+     */
+    public PreparedStatement getStatement() {
+        return statement.getStatement();
+    }
+
+    /**
+     * Add a new row to the batch. Only call this method if you have set all values
+     * on the {@link PreparedStatement} retrieved from {@link #statement}.
+     * <p>
+     * Don't call this if you use {@link #add(PreparedStatementSetter)}.
+     */
+    public void addBatch() {
         statement.addBatch();
         currentBatchSize++;
         rows++;

--- a/src/test/java/org/itsallcode/jdbc/SimplePreparedStatementTest.java
+++ b/src/test/java/org/itsallcode/jdbc/SimplePreparedStatementTest.java
@@ -129,6 +129,11 @@ class SimplePreparedStatementTest {
                 .hasMessage("Error getting parameter metadata: expected");
     }
 
+    @Test
+    void getStatement() {
+        assertThat(testee().getStatement()).isSameAs(statementMock);
+    }
+
     SimplePreparedStatement testee() {
         return new SimplePreparedStatement(null, null, statementMock, SQL_QUERY);
     }

--- a/src/test/java/org/itsallcode/jdbc/batch/BatchInsertTest.java
+++ b/src/test/java/org/itsallcode/jdbc/batch/BatchInsertTest.java
@@ -1,0 +1,110 @@
+package org.itsallcode.jdbc.batch;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.*;
+
+import java.sql.PreparedStatement;
+
+import org.itsallcode.jdbc.PreparedStatementSetter;
+import org.itsallcode.jdbc.SimplePreparedStatement;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BatchInsertTest {
+
+    @Mock
+    SimplePreparedStatement stmtMock;
+    @Mock
+    PreparedStatementSetter stmtSetterMock;
+
+    @Test
+    void addDoesNotFlush() {
+        final BatchInsert testee = testee(2);
+        testee.add(stmtSetterMock);
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock).setValues(same(stmtSetterMock));
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void addFlushesAfterBatchSizeReached() {
+        final BatchInsert testee = testee(2);
+        when(stmtMock.executeBatch()).thenReturn(new int[0]);
+
+        testee.add(stmtSetterMock);
+        testee.add(stmtSetterMock);
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock).setValues(same(stmtSetterMock));
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verify(stmtMock).setValues(same(stmtSetterMock));
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verify(stmtMock).executeBatch();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void addBatchDoesNotFlush() {
+        final BatchInsert testee = testee(2);
+        testee.addBatch();
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void addBatchFlushesAfterBatchSizeReached() {
+        final BatchInsert testee = testee(2);
+        when(stmtMock.executeBatch()).thenReturn(new int[0]);
+
+        testee.addBatch();
+        testee.addBatch();
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock, times(2)).addBatch();
+        inOrder.verify(stmtMock).executeBatch();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void closeClosesStatement() {
+        final BatchInsert testee = testee(2);
+        testee.close();
+        verify(stmtMock).close();
+    }
+
+    @Test
+    void closeFlushes() {
+        final BatchInsert testee = testee(2);
+        when(stmtMock.executeBatch()).thenReturn(new int[0]);
+
+        testee.add(stmtSetterMock);
+        testee.close();
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verify(stmtMock).executeBatch();
+        inOrder.verify(stmtMock).close();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void getStatement() {
+        final BatchInsert testee = testee(2);
+        final PreparedStatement preparedStmtMock = mock(PreparedStatement.class);
+        when(stmtMock.getStatement()).thenReturn(preparedStmtMock);
+        assertThat(testee.getStatement()).isSameAs(preparedStmtMock);
+    }
+
+    BatchInsert testee(final int maxBatchSize) {
+        return new BatchInsert(stmtMock, maxBatchSize);
+    }
+}

--- a/src/test/java/org/itsallcode/jdbc/batch/RowBatchInsertTest.java
+++ b/src/test/java/org/itsallcode/jdbc/batch/RowBatchInsertTest.java
@@ -1,8 +1,7 @@
 package org.itsallcode.jdbc.batch;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.inOrder;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.itsallcode.jdbc.RowPreparedStatementSetter;
 import org.itsallcode.jdbc.SimplePreparedStatement;
@@ -32,7 +31,7 @@ class RowBatchInsertTest {
     }
 
     @Test
-    void addDoesNotFlushesAfterBatchSizeReached() {
+    void addFlushesAfterBatchSizeReached() {
         final RowBatchInsert<Row> testee = testee(2);
         when(stmtMock.executeBatch()).thenReturn(new int[0]);
 
@@ -45,6 +44,28 @@ class RowBatchInsertTest {
         inOrder.verify(stmtMock).setValues(any());
         inOrder.verify(stmtMock).addBatch();
         inOrder.verify(stmtMock).executeBatch();
+        inOrder.verifyNoMoreInteractions();
+    }
+
+    @Test
+    void closeClosesStatement() {
+        final RowBatchInsert<Row> testee = testee(2);
+        testee.close();
+        verify(stmtMock).close();
+    }
+
+    @Test
+    void closeFlushes() {
+        final RowBatchInsert<Row> testee = testee(2);
+        when(stmtMock.executeBatch()).thenReturn(new int[0]);
+
+        testee.add(new Row());
+        testee.close();
+
+        final InOrder inOrder = inOrder(stmtMock);
+        inOrder.verify(stmtMock).addBatch();
+        inOrder.verify(stmtMock).executeBatch();
+        inOrder.verify(stmtMock).close();
         inOrder.verifyNoMoreInteractions();
     }
 

--- a/src/test/java/org/itsallcode/jdbc/example/ExampleTest.java
+++ b/src/test/java/org/itsallcode/jdbc/example/ExampleTest.java
@@ -111,6 +111,38 @@ class ExampleTest {
         }
     }
 
+    @Test
+    void exampleRawBatchInsert() {
+        final ConnectionFactory connectionFactory = ConnectionFactory
+                .create(Context.builder().build());
+        try (SimpleConnection connection = connectionFactory.create("jdbc:h2:mem:", "user", "password")) {
+            try (Transaction transaction = connection.startTransaction()) {
+                transaction.executeScript(readResource("/schema.sql"));
+                try (BatchInsert batch = transaction.batchInsert()
+                        .into("NAMES", List.of("ID", "NAME"))
+                        .maxBatchSize(100)
+                        .build()) {
+                    for (int i = 0; i < 5; i++) {
+                        final int id = i + 1;
+                        batch.add(ps -> {
+                            ps.setInt(1, id);
+                            ps.setString(2, "name" + id);
+                        });
+                    }
+                }
+                transaction.commit();
+            }
+
+            try (SimpleResultSet<Row> rs = connection.query("select * from names order by id")) {
+                final List<Row> result = rs.stream().toList();
+                assertEquals(5, result.size());
+                final Row firstRow = result.get(0);
+                assertEquals(1, firstRow.get(0).value());
+                assertEquals("name1", firstRow.get(1).value());
+            }
+        }
+    }
+
     private String readResource(final String resourceName) {
         final URL resource = getClass().getResource(resourceName);
         if (resource == null) {

--- a/src/test/java/org/itsallcode/jdbc/example/ExampleTest.java
+++ b/src/test/java/org/itsallcode/jdbc/example/ExampleTest.java
@@ -112,7 +112,7 @@ class ExampleTest {
     }
 
     @Test
-    void exampleRawBatchInsert() {
+    void exampleRawBatchInsert() throws SQLException {
         final ConnectionFactory connectionFactory = ConnectionFactory
                 .create(Context.builder().build());
         try (SimpleConnection connection = connectionFactory.create("jdbc:h2:mem:", "user", "password")) {
@@ -122,12 +122,12 @@ class ExampleTest {
                         .into("NAMES", List.of("ID", "NAME"))
                         .maxBatchSize(100)
                         .build()) {
+                    final PreparedStatement statement = batch.getStatement();
                     for (int i = 0; i < 5; i++) {
                         final int id = i + 1;
-                        batch.add(ps -> {
-                            ps.setInt(1, id);
-                            ps.setString(2, "name" + id);
-                        });
+                        statement.setInt(1, id);
+                        statement.setString(2, "name" + id);
+                        batch.addBatch();
                     }
                 }
                 transaction.commit();


### PR DESCRIPTION
Allow direct access to PreparedStatement for batch insert. This is useful when the callback `BatchInsert.add()` is not usable in some cases.